### PR TITLE
chore: add individual dev scripts

### DIFF
--- a/apps/submission-manager/package.json
+++ b/apps/submission-manager/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "pnpm exec esbuild index.ts --bundle --platform=node --outfile=submission-manager.cjs",
     "cache": "pnpm --filter @easyshell/problems run cache:submission-manager",
+    "dev": "pnpm run build && pnpm run start",
     "start": "node submission-manager.cjs"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
   "type": "module",
   "scripts": {
     "cache": "pnpm --filter @easyshell/problems run cache:website && pnpm --filter @easyshell/problems run cache:submission-manager",
-    "dev:up": "infisical run --env=dev -- docker compose up -d",
+    "dev:session-manager": "infisical run --env=dev -- go run -C apps/session-manager .",
+    "dev:submission-manager": "infisical run --env=dev -- pnpm --filter @easyshell/submission-manager run dev",
+    "dev:website": "infisical run --env=dev -- pnpm --filter @easyshell/website run dev",
+    "docker:build": "infisical run --env=dev -- docker compose build",
+    "docker:up": "infisical run --env=dev -- docker compose up -d",
     "format:check": "pnpm exec prettier --check . && gofmt -l -s .",
     "format:write": "pnpm exec prettier --write . && gofmt -w -s .",
     "lint": "pnpm run lint:tsc && pnpm run lint:next",


### PR DESCRIPTION
- Add per-service dev scripts for session-manager,
  submission-manager, and website with infisical env
- Add dev script to submission-manager for build+start
- Rename dev:up to docker:up and add docker:build script
  for clearer separation of local dev vs Docker workflows
