### PR TITLE
fix: move router.replace() into useEffect to prevent SSR crash on login page

### DIFF
--- a/apps/website/src/app/login/client.tsx
+++ b/apps/website/src/app/login/client.tsx
@@ -20,18 +20,20 @@ export function Client({ loggedIn }: { loggedIn: boolean }) {
     callback = "/"
   }
 
-  if (callback === "/") {
-    router.replace("/login")
-  } else if (callback != null) {
-    router.replace(`/login?callback=${callback}`)
-  }
-
   useEffect(() => {
     if (loggedIn) {
       toast("You are already logged in")
       if (validCallbackUrl(callback)) {
         router.push(callback ?? "/")
       }
+      return
+    }
+
+    // Clean up the URL by stripping invalid/unnecessary params
+    if (callback === "/") {
+      router.replace("/login")
+    } else if (callback != null) {
+      router.replace(`/login?callback=${callback}`)
     }
   }, [router, loggedIn, callback])
 


### PR DESCRIPTION
## Summary

- Fixes `ReferenceError: location is not defined` crash during server-side rendering of the login page
- Moves `router.replace()` calls from the render phase into a `useEffect`, ensuring they only execute client-side after hydration when the browser `location` global is available

## Root Cause

`router.replace()` was called during the render body of the `Client` component in `apps/website/src/app/login/client.tsx`. Despite the `"use client"` directive, Next.js still SSRs client components for initial HTML. The `router.replace()` call triggers `dispatchNavigateAction` in Next.js internals, which references bare `location.href` — a browser-only global that doesn't exist in Node.js — causing the uncaught `ReferenceError`.